### PR TITLE
use generator for line processing

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -17,11 +17,11 @@ def get_data(line):
 
 
 def main(filename, dstfilename):
-    with open(filename, 'r') as f:
-        data = [get_data(line.strip()) for line in f]
-    
-    with open(dstfilename, 'w') as f:
-        f.write('\n'.join(f'{num:X};{name}' for (num, name) in data))
+    with open(filename, 'r') as src:
+        data = (get_data(line.strip()) for line in src)
+
+        with open(dstfilename, 'w') as dst:
+            dst.write('\n'.join(f'{num:X};{name}' for (num, name) in data))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reduces memory usage by not loading the entire file into memory, but instead operating only on one line at a time. 

Benchmarking with /usr/bin/time -v shows a memory improvement (although for testing i commented out a check in `get_data` involving control characters which was not working for me).
![image](https://user-images.githubusercontent.com/15344581/52718814-36110700-2f9c-11e9-909f-9f2416b51d6d.png)
The left side is the generator version, and it shows that the maximum resident set size is about 6MB less, which is about a 30% memory improvement. UnicodeDataFixed itself is about 1MB, so I guess python imposes a 6x overhead.

Also apparently the generator version has fewer minor page faults. No idea why.